### PR TITLE
Added configuration option to disable the use of the default routes

### DIFF
--- a/config/initializers/comfy_blog.rb
+++ b/config/initializers/comfy_blog.rb
@@ -22,4 +22,7 @@ ComfyBlog.configure do |config|
   # Default is false.
   #   config.auto_publish_comments = false
   
+  # Include the default routes
+  # If you want to include the routes manually set this to false
+  #   config.use_default_routes = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,4 @@ Rails.application.routes.draw do
     get ':id' => 'posts#show', :as => :blog_post
   end
   
-end
+end if ComfyBlog.config.use_default_routes

--- a/lib/comfy_blog/configuration.rb
+++ b/lib/comfy_blog/configuration.rb
@@ -34,6 +34,9 @@ module ComfyBlog
     # Comments can be fully handled by Disqus. Set this config to use it.
     attr_accessor :disqus_shortname
     
+    # If you want to include the routes manually set this to false
+    attr_accessor :use_default_routes
+    
     # Configuration defaults
     def initialize
       @title                  = 'ComfyBlog'
@@ -46,6 +49,7 @@ module ComfyBlog
       @posts_per_page         = 10
       @auto_publish_comments  = false
       @disqus_shortname       = nil
+      @use_default_routes     = true
     end
     
   end


### PR DESCRIPTION
Unlike Comfortable Mexican Sofa, Comfy-blog loads its built-in routes
by default and there is no way to customize them or the sequence in
which all routes are loaded.
To remedy this a new option 'use_default_routes' is added in
config/initializers/comfy_blog.rb that mimics the behavior of the same
option present in Comfortable Mexican Sofa.
