### PR TITLE
Allow user to disable comments on posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Gemfile.lock
 .ruby-version
 /.sass-cache
 coverage/
+# Ignore Rubymine files
+.idea

--- a/app/controllers/comfy/blog/comments_controller.rb
+++ b/app/controllers/comfy/blog/comments_controller.rb
@@ -1,14 +1,14 @@
 class Comfy::Blog::CommentsController < Comfy::Blog::BaseController
-  
+
   before_action :load_post,
                 :build_comment
-  
+
   def create
     @comment.save!
-    
+
     flash[:success] = 'Comment created'
     redirect_to comfy_blog_post_path(@cms_site.path, @blog.path, @post.slug)
-    
+
   rescue ActiveRecord::RecordInvalid
     flash[:error] = 'Failed to create Comment'
     render 'comfy/blog/posts/show'
@@ -22,7 +22,7 @@ protected
     flash[:error] = 'Blog Post not found'
     redirect_to comfy_blog_posts_path(@cms_site.path, @blog.path)
   end
-  
+
   def build_comment
     @comment = @post.comments.new(comment_params)
   end

--- a/app/controllers/comfy/blog/comments_controller.rb
+++ b/app/controllers/comfy/blog/comments_controller.rb
@@ -5,7 +5,6 @@ class Comfy::Blog::CommentsController < Comfy::Blog::BaseController
 
   def create
     @comment.save!
-
     flash[:success] = 'Comment created'
     redirect_to comfy_blog_post_path(@cms_site.path, @blog.path, @post.slug)
 

--- a/app/models/comfy/blog/comment.rb
+++ b/app/models/comfy/blog/comment.rb
@@ -14,7 +14,7 @@ class Comfy::Blog::Comment < ActiveRecord::Base
   validates :email,
     :format => { :with => /\A([\w.%-+]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
 
-  validate :comments_allowed
+  validate :check_commentable
 
   # -- Scopes ---------------------------------------------------------------
   scope :published, -> {
@@ -28,7 +28,7 @@ protected
     return
   end
 
-  def comments_allowed
-    errors.add(:base, 'comments are not allowed') unless ComfyBlog.config.allow_comments
+  def check_commentable
+    errors.add(:base, 'comments are not allowed') if post.try(:comments_disabled?)
   end
 end

--- a/app/models/comfy/blog/comment.rb
+++ b/app/models/comfy/blog/comment.rb
@@ -1,29 +1,34 @@
 class Comfy::Blog::Comment < ActiveRecord::Base
-  
+
   self.table_name = 'comfy_blog_comments'
-  
+
   # -- Relationships --------------------------------------------------------
   belongs_to :post
-  
+
   # -- Callbacks ------------------------------------------------------------
   before_create :set_is_published
-    
+
   # -- Validations ----------------------------------------------------------
-  validates :post_id, :content, :author, :email, 
+  validates :post_id, :content, :author, :email,
     :presence => true
   validates :email,
     :format => { :with => /\A([\w.%-+]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
-    
+
+  validate :comments_allowed
+
   # -- Scopes ---------------------------------------------------------------
   scope :published, -> {
     where(:is_published => true)
   }
-  
+
 protected
-  
+
   def set_is_published
     self.is_published = ComfyBlog.config.auto_publish_comments
     return
   end
-  
+
+  def comments_allowed
+    errors.add(:base, 'comments are not allowed') unless ComfyBlog.config.allow_comments
+  end
 end

--- a/app/models/comfy/blog/post.rb
+++ b/app/models/comfy/blog/post.rb
@@ -1,20 +1,20 @@
 class Comfy::Blog::Post < ActiveRecord::Base
-  
+
   self.table_name = 'comfy_blog_posts'
-  
+
   # -- Relationships --------------------------------------------------------
   belongs_to :blog
-  
+
   has_many :comments,
     :dependent => :destroy
-  
+
   # -- Validations ----------------------------------------------------------
   validates :blog_id, :title, :slug, :year, :month, :content,
     :presence   => true
   validates :slug,
     :uniqueness => { :scope => [:blog_id, :year, :month] },
     :format     => { :with => /\A\w[a-z0-9_-]*\z/i }
-  
+
   # -- Scopes ---------------------------------------------------------------
   default_scope -> {
     order('published_at DESC')
@@ -28,25 +28,29 @@ class Comfy::Blog::Post < ActiveRecord::Base
   scope :for_month, -> month {
     where(:month => month)
   }
-  
+
   # -- Callbacks ------------------------------------------------------------
   before_validation :set_slug,
                     :set_published_at,
                     :set_date
-  
+
+  def comments_disabled?
+    !ComfyBlog.config.allow_comments || !is_commentable
+  end
+
 protected
-  
+
   def set_slug
     self.slug ||= self.title.to_s.downcase.slugify
   end
-  
+
   def set_date
     self.year   = self.published_at.year
     self.month  = self.published_at.month
   end
-  
+
   def set_published_at
     self.published_at ||= Time.zone.now
   end
-  
+
 end

--- a/app/views/comfy/admin/blog/posts/_form.html.haml
+++ b/app/views/comfy/admin/blog/posts/_form.html.haml
@@ -6,6 +6,8 @@
 = form.text_field :published_at, :value => @post.published_at.try(:to_s, :db), :data => {'cms-datetime' => true}
 = form.form_group :is_published do
   = form.check_box :is_published
+= form.form_group :is_commentable do
+  = form.check_box :is_commentable
 
 = form.form_group :class => 'form-actions' do
   = form.submit :class => 'btn btn-primary'

--- a/app/views/comfy/blog/comments/_index.html.haml
+++ b/app/views/comfy/blog/comments/_index.html.haml
@@ -1,0 +1,4 @@
+- @post.comments.published.each do |comment|
+  .comment
+    .author= comment.author
+    .content= comment.content

--- a/app/views/comfy/blog/posts/show.html.haml
+++ b/app/views/comfy/blog/posts/show.html.haml
@@ -9,10 +9,7 @@
 .content
   = @post.content.html_safe
 
-.comments
-  - @post.comments.published.each do |comment|
-    .comment
-      .author= comment.author
-      .content= comment.content
-  
-  = render :partial => 'comfy/blog/comments/form'
+- if ComfyBlog.config.allow_comments
+  .comments
+    = render :partial => 'comfy/blog/comments/index'
+    = render :partial => 'comfy/blog/comments/form'

--- a/app/views/comfy/blog/posts/show.html.haml
+++ b/app/views/comfy/blog/posts/show.html.haml
@@ -9,7 +9,7 @@
 .content
   = @post.content.html_safe
 
-- if ComfyBlog.config.allow_comments
+- unless @post.comments_disabled?
   .comments
     = render :partial => 'comfy/blog/comments/index'
     = render :partial => 'comfy/blog/comments/form'

--- a/config/initializers/comfy_blog.rb
+++ b/config/initializers/comfy_blog.rb
@@ -3,6 +3,10 @@ ComfyBlog.configure do |config|
   # Number of posts per page. Default is 10
   #   config.posts_per_page = 10
 
+  # Enable/disable comments on posts
+  # Default is true
+  #   config.allow_comments = false
+
   # Comments can be automatically approved/published by changing this setting
   # Default is false.
   #   config.auto_publish_comments = false

--- a/db/migrate/01_create_blog.rb
+++ b/db/migrate/01_create_blog.rb
@@ -1,5 +1,5 @@
 class CreateBlog < ActiveRecord::Migration
-  
+
   def self.up
     create_table :comfy_blogs do |t|
       t.integer :site_id,     :null => false
@@ -11,25 +11,26 @@ class CreateBlog < ActiveRecord::Migration
     end
     add_index :comfy_blogs, [:site_id, :path]
     add_index :comfy_blogs, :identifier
-    
+
     create_table :comfy_blog_posts do |t|
-      t.integer   :blog_id,       :null => false
-      t.string    :title,         :null => false
-      t.string    :slug,          :null => false
+      t.integer   :blog_id,        :null => false
+      t.string    :title,          :null => false
+      t.string    :slug,           :null => false
       t.text      :content
-      t.string    :excerpt,       :limit => 1024
+      t.string    :excerpt,        :limit => 1024
       t.string    :author
-      t.integer   :year,          :null => false, :limit => 4
-      t.integer   :month,         :null => false, :limit => 2
-      t.boolean   :is_published,  :null => false, :default => true
-      t.datetime  :published_at,  :null => false
+      t.integer   :year,           :null => false, :limit => 4
+      t.integer   :month,          :null => false, :limit => 2
+      t.boolean   :is_published,   :null => false, :default => true
+      t.boolean   :is_commentable, :null => false, :default => true
+      t.datetime  :published_at,   :null => false
       t.timestamps
     end
     add_index :comfy_blog_posts, [:is_published, :year, :month, :slug],
       :name => 'index_blog_posts_on_published_year_month_slug'
     add_index :comfy_blog_posts, [:is_published, :created_at]
     add_index :comfy_blog_posts, :created_at
-    
+
     create_table :comfy_blog_comments do |t|
       t.integer :post_id,       :null => false
       t.string  :author,        :null => false
@@ -42,11 +43,11 @@ class CreateBlog < ActiveRecord::Migration
     add_index :comfy_blog_comments, [:post_id, :is_published, :created_at],
       :name => 'index_blog_comments_on_post_published_created'
   end
-  
+
   def self.down
     drop_table :comfy_blogs
     drop_table :comfy_posts
     drop_table :comfy_comments
   end
-  
+
 end

--- a/lib/comfy_blog/configuration.rb
+++ b/lib/comfy_blog/configuration.rb
@@ -4,16 +4,21 @@ module ComfyBlog
     # Number of posts per page. Default is 10
     attr_accessor :posts_per_page
 
+    # Enable/disable comments on posts
+    # Default is true
+    attr_accessor :allow_comments
+
     # Comments can be automatically approved/published by changing this setting
     # Default is false.
     attr_accessor :auto_publish_comments
-    
+
     # A default author can be specified for posts
     attr_accessor :default_author
 
     # Configuration defaults
     def initialize
       @posts_per_page         = 10
+      @allow_comments         = true
       @auto_publish_comments  = false
       @default_author         = nil
     end

--- a/test/controllers/comfy/blog/comments_controller_test.rb
+++ b/test/controllers/comfy/blog/comments_controller_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 
 class Comfy::Blog::CommentsControllerTest < ActionController::TestCase
-  
+
   def setup
     @blog = comfy_blog_blogs(:default)
     @post = comfy_blog_posts(:default)
@@ -17,13 +17,13 @@ class Comfy::Blog::CommentsControllerTest < ActionController::TestCase
       assert_response :redirect
       assert_redirected_to comfy_blog_post_path
       assert_equal 'Comment created', flash[:success]
-      
+
       comment = Comfy::Blog::Comment.last
       assert_equal 'Test', comment.author
       assert_equal @post, comment.post
     end
   end
-  
+
   def test_creation_failure
     assert_no_difference 'Comfy::Blog::Comment.count' do
       post :create, :slug => @post.slug, :comment => { }

--- a/test/controllers/comfy/blog/posts_controller_test.rb
+++ b/test/controllers/comfy/blog/posts_controller_test.rb
@@ -1,80 +1,82 @@
 require_relative '../../../test_helper'
 
 class Comfy::Blog::PostsControllerTest < ActionController::TestCase
-  
+
   def setup
     @blog = comfy_blog_blogs(:default)
     @post = comfy_blog_posts(:default)
+    @second_post = comfy_blog_posts(:not_commentable)
   end
-  
+
   def test_get_index
     get :serve
     assert_response :success
     assert_template :index
     assert assigns(:posts)
-    assert_equal 1, assigns(:posts).size
+    assert_equal 2, assigns(:posts).size
   end
-  
+
   def test_get_index_as_rss
     get :serve, :format => :rss
     assert_response :success
     assert_template :index
     assert assigns(:posts)
-    assert_equal 1, assigns(:posts).size
+    assert_equal 2, assigns(:posts).size
   end
-  
+
   def test_get_index_with_unpublished
     comfy_blog_posts(:default).update_column(:is_published, false)
     get :serve
     assert_response :success
-    assert_equal 0, assigns(:posts).size
+    assert_equal 1, assigns(:posts).size
   end
-  
+
   def test_get_index_for_year_archive
     get :index, :year => 2012
     assert_response :success
-    assert_equal 1, assigns(:posts).size
-    
+    assert_equal 2, assigns(:posts).size
+
     get :index, :year => 1999
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_index_for_month_archive
     get :index, :year => 2012, :month => 1
     assert_response :success
-    assert_equal 1, assigns(:posts).size
-    
+    assert_equal 2, assigns(:posts).size
+
     get :index, :year => 2012, :month => 12
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_show
     get :serve, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_unpublished
     @post.update_attribute(:is_published, false)
+    @second_post.update_attribute(:is_published, false)
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :serve, :slug => @post.slug
     end
   end
-  
+
   def test_get_show_with_date
     get :show, :year => @post.year, :month => @post.month, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_with_date_invalid
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :show, :year => '1999', :month => '99', :slug => 'invalid'
     end
   end
-  
+
 end

--- a/test/fixtures/comfy/blog/posts.yml
+++ b/test/fixtures/comfy/blog/posts.yml
@@ -5,6 +5,18 @@ default:
   content: Default Content
   author: Default Author
   is_published: true
+  is_commentable: true
+  year: 2012
+  month: 1
+  published_at: <%= 2.days.ago %>
+not_commentable:
+  blog: default
+  title: Another Title
+  slug: another-title
+  content: Another Content
+  author: Another Author
+  is_published: true
+  is_commentable: false
   year: 2012
   month: 1
   published_at: <%= 2.days.ago %>

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -5,6 +5,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   def test_configuration
     assert config = ComfyBlog.configuration
     assert_equal 10,    config.posts_per_page
+    assert_equal true, config.allow_comments
     assert_equal false, config.auto_publish_comments
     assert_equal nil,   config.default_author
   end

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 class BlogTest < ActiveSupport::TestCase
-  
+
   def test_site_association
     assert_equal [comfy_blog_blogs(:default)], comfy_cms_sites(:default).blogs
   end
@@ -11,36 +11,36 @@ class BlogTest < ActiveSupport::TestCase
       assert blog.valid?, blog.errors.inspect
     end
   end
-  
+
   def test_validation
     blog = Comfy::Blog::Blog.new
     assert blog.invalid?
     assert_errors_on blog, :site_id, :label, :identifier, :path
   end
-  
+
   def test_validation_path_presence
     blog_a = comfy_blog_blogs(:default)
     refute blog_a.path.present?
-    
+
     blog_b = comfy_cms_sites(:default).blogs.new(
       :label      => 'Test Blog A',
       :identifier => 'test-blog-a'
     )
     assert blog_b.invalid?
     assert_errors_on blog_b, :path
-    
+
     blog_a.update_column(:path, 'blog-a')
     assert blog_b.invalid?
     assert_errors_on blog_b, :path
-    
+
     blog_b.path = 'blog-a'
     assert blog_b.invalid?
     assert_errors_on blog_b, :path
-    
+
     blog_b.path = 'blog-b'
     assert blog_b.valid?
   end
-  
+
   def test_creation
     assert_difference 'Comfy::Blog::Blog.count' do
       comfy_cms_sites(:default).blogs.create(
@@ -50,10 +50,13 @@ class BlogTest < ActiveSupport::TestCase
       )
     end
   end
-  
+
   def test_destroy
-    assert_difference ['Comfy::Blog::Blog.count', 'Comfy::Blog::Post.count'], -1 do
-      comfy_blog_blogs(:default).destroy
-    end
+    assert_equal Comfy::Blog::Blog.count, 1
+    assert_equal Comfy::Blog::Post.count, 2
+
+    comfy_blog_blogs(:default).destroy
+    assert_equal Comfy::Blog::Blog.count, 0
+    assert_equal Comfy::Blog::Post.count, 0
   end
 end

--- a/test/models/comments_test.rb
+++ b/test/models/comments_test.rb
@@ -14,11 +14,30 @@ class BlogCommentsTest < ActiveSupport::TestCase
     assert_errors_on comment, [:post_id, :content, :author, :email]
   end
 
-  def test_validations_when_comments_not_allowed
+  def test_validations_when_comments_not_allowed_for_blog
     ComfyBlog.config.allow_comments = false
-    comment = Comfy::Blog::Comment.new
+    post = comfy_blog_posts(:default)
+    comment = Comfy::Blog::Comment.new(
+        :content  => 'Test Content',
+        :author   => 'Tester',
+        :email    => 'test@test.test',
+        :post_id  => post.id
+    )
     assert comment.invalid?
+    assert_errors_on comment, :base
     ComfyBlog.config.allow_comments = true
+  end
+
+  def test_validations_when_post_is_not_commentable
+    post = comfy_blog_posts(:not_commentable)
+    comment = Comfy::Blog::Comment.new(
+        :content  => 'Test Content',
+        :author   => 'Tester',
+        :email    => 'test@test.test',
+        :post_id  => post.id
+    )
+    assert comment.invalid?
+    assert_errors_on comment, :base
   end
 
   def test_creation

--- a/test/models/comments_test.rb
+++ b/test/models/comments_test.rb
@@ -1,19 +1,26 @@
 require_relative '../test_helper'
 
 class BlogCommentsTest < ActiveSupport::TestCase
-  
+
   def test_fixtures_validity
     Comfy::Blog::Comment.all.each do |comment|
       assert comment.valid?, comment.errors.full_messages.to_s
     end
   end
-  
+
   def test_validations
     comment = Comfy::Blog::Comment.new
     assert comment.invalid?
     assert_errors_on comment, [:post_id, :content, :author, :email]
   end
-  
+
+  def test_validations_when_comments_not_allowed
+    ComfyBlog.config.allow_comments = false
+    comment = Comfy::Blog::Comment.new
+    assert comment.invalid?
+    ComfyBlog.config.allow_comments = true
+  end
+
   def test_creation
     assert_difference 'Comfy::Blog::Comment.count' do
       comment = comfy_blog_posts(:default).comments.create(
@@ -24,10 +31,10 @@ class BlogCommentsTest < ActiveSupport::TestCase
       assert !comment.is_published?
     end
   end
-  
+
   def test_creation_with_auto_publishing
     ComfyBlog.config.auto_publish_comments = true
-    
+
     comment = comfy_blog_posts(:default).comments.create(
       :content  => 'Test Content',
       :author   => 'Tester',
@@ -35,11 +42,11 @@ class BlogCommentsTest < ActiveSupport::TestCase
     )
     assert comment.is_published?
   end
-  
+
   def test_scope_published
     assert_equal 1, Comfy::Blog::Comment.published.count
     comfy_blog_comments(:default).update_attribute(:is_published, false)
     assert_equal 0, Comfy::Blog::Comment.published.count
   end
-  
+
 end

--- a/test/models/posts_test.rb
+++ b/test/models/posts_test.rb
@@ -1,19 +1,19 @@
 require_relative '../test_helper'
 
 class BlogPostsTest < ActiveSupport::TestCase
-  
+
   def test_fixtures_validity
     Comfy::Blog::Post.all.each do |post|
       assert post.valid?, post.errors.full_messages.to_s
     end
   end
-  
+
   def test_validations
     post = Comfy::Blog::Post.new
     assert post.invalid?
     assert_errors_on post, :blog_id, :title, :slug, :content
   end
-  
+
   def test_validation_of_slug_uniqueness
     old_post = comfy_blog_posts(:default)
     old_post.update_attributes!(:published_at => Time.now)
@@ -27,7 +27,7 @@ class BlogPostsTest < ActiveSupport::TestCase
     old_post.update_attributes!(:published_at => 1.year.ago)
     assert post.valid?
   end
-  
+
   def test_creation
     assert_difference 'Comfy::Blog::Post.count' do
       post = comfy_blog_blogs(:default).posts.create!(
@@ -39,13 +39,13 @@ class BlogPostsTest < ActiveSupport::TestCase
       assert_equal Time.now.month, post.month
     end
   end
-  
+
   def test_set_slug
     post = Comfy::Blog::Post.new(:title => 'Test Title')
     post.send(:set_slug)
     assert_equal 'test-title', post.slug
   end
-  
+
   def test_set_date
     post = Comfy::Blog::Post.new
     post.send(:set_published_at)
@@ -53,13 +53,13 @@ class BlogPostsTest < ActiveSupport::TestCase
     assert_equal post.published_at.year, post.year
     assert_equal post.published_at.month, post.month
   end
-  
+
   def test_set_published_at
     post = Comfy::Blog::Post.new
     post.send(:set_published_at)
     assert post.published_at.present?
   end
-  
+
   def test_destroy
     assert_difference ['Comfy::Blog::Post.count', 'Comfy::Blog::Comment.count'], -1 do
       comfy_blog_posts(:default).destroy
@@ -69,20 +69,20 @@ class BlogPostsTest < ActiveSupport::TestCase
   def test_scope_published
     post = comfy_blog_posts(:default)
     assert post.is_published?
-    assert_equal 1, Comfy::Blog::Post.published.count
+    assert_equal 2, Comfy::Blog::Post.published.count
 
     post.update_attribute(:is_published, false)
-    assert_equal 0, Comfy::Blog::Post.published.count
+    assert_equal 1, Comfy::Blog::Post.published.count
   end
 
   def test_scope_for_year
-    assert_equal 1, Comfy::Blog::Post.for_year(2012).count
+    assert_equal 2, Comfy::Blog::Post.for_year(2012).count
     assert_equal 0, Comfy::Blog::Post.for_year(2013).count
   end
 
   def test_scope_for_month
-    assert_equal 1, Comfy::Blog::Post.for_month(1).count
+    assert_equal 2, Comfy::Blog::Post.for_month(1).count
     assert_equal 0, Comfy::Blog::Post.for_month(2).count
   end
-  
+
 end


### PR DESCRIPTION
There are some cases when it is needed to switch off comments on existing blog. It can be done by setting

```
config.allow_comments = false 
```
