### PR TITLE
Allow action to be configured when rescuing from ActiveRecord::RecordNotFound

### DIFF
--- a/app/controllers/comfy/blog/posts_controller.rb
+++ b/app/controllers/comfy/blog/posts_controller.rb
@@ -47,7 +47,7 @@ class Comfy::Blog::PostsController < Comfy::Blog::BaseController
     @comment = @post.comments.new
 
   rescue ActiveRecord::RecordNotFound
-    render :cms_page => '/404', :status => 404
+    instance_eval(&ComfyBlog.config.post_not_found)
   end
 
 end

--- a/lib/comfy_blog/configuration.rb
+++ b/lib/comfy_blog/configuration.rb
@@ -7,15 +7,19 @@ module ComfyBlog
     # Comments can be automatically approved/published by changing this setting
     # Default is false.
     attr_accessor :auto_publish_comments
-    
+
     # A default author can be specified for posts
     attr_accessor :default_author
+
+    # A proc to be called when a post cannot be found
+    attr_accessor :post_not_found
 
     # Configuration defaults
     def initialize
       @posts_per_page         = 10
       @auto_publish_comments  = false
       @default_author         = nil
+      @post_not_found = Proc.new { render :cms_page => '/404', :status => 404 }
     end
 
   end

--- a/test/controllers/comfy/blog/posts_controller_test.rb
+++ b/test/controllers/comfy/blog/posts_controller_test.rb
@@ -1,12 +1,12 @@
 require_relative '../../../test_helper'
 
 class Comfy::Blog::PostsControllerTest < ActionController::TestCase
-  
+
   def setup
     @blog = comfy_blog_blogs(:default)
     @post = comfy_blog_posts(:default)
   end
-  
+
   def test_get_index
     get :serve
     assert_response :success
@@ -14,7 +14,7 @@ class Comfy::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:posts)
     assert_equal 1, assigns(:posts).size
   end
-  
+
   def test_get_index_as_rss
     get :serve, :format => :rss
     assert_response :success
@@ -22,59 +22,71 @@ class Comfy::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:posts)
     assert_equal 1, assigns(:posts).size
   end
-  
+
   def test_get_index_with_unpublished
     comfy_blog_posts(:default).update_column(:is_published, false)
     get :serve
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_index_for_year_archive
     get :index, :year => 2012
     assert_response :success
     assert_equal 1, assigns(:posts).size
-    
+
     get :index, :year => 1999
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_index_for_month_archive
     get :index, :year => 2012, :month => 1
     assert_response :success
     assert_equal 1, assigns(:posts).size
-    
+
     get :index, :year => 2012, :month => 12
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_show
     get :serve, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_unpublished
     @post.update_attribute(:is_published, false)
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :serve, :slug => @post.slug
     end
   end
-  
+
   def test_get_show_with_date
     get :show, :year => @post.year, :month => @post.month, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_with_date_invalid
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :show, :year => '1999', :month => '99', :slug => 'invalid'
     end
   end
-  
+
+  def test_custom_post_not_found_proc_called
+    original = ComfyBlog.config.post_not_found
+    begin
+      ComfyBlog.config.post_not_found = Proc.new { raise 'Oh no' }
+      assert_exception_raised RuntimeError do
+        get :serve, :slug => 'not-here'
+      end
+    ensure
+      ComfyBlog.config.post_not_found = original
+    end
+  end
+
 end


### PR DESCRIPTION
This PR allows behaviour when user tries to view a post which does not exist (or is not published) to be configured by the parent app. This is for cases where the parent app might not want to render a 404 CMS page. By default it performs the same action as it does right now.
