### PR TITLE
Add categories to blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ComfyBlog is an simple blog management engine for [ComfortableMexicanSofa](https
 
 * Ability to set up multiple blogs per site
 * User defined layout per blog
+* Filter blog posts by category
 
 ## Installation
 

--- a/app/controllers/comfy/admin/blog/posts_controller.rb
+++ b/app/controllers/comfy/admin/blog/posts_controller.rb
@@ -5,7 +5,7 @@ class Comfy::Admin::Blog::PostsController < Comfy::Admin::Blog::BaseController
   before_action :load_post,  :only => [:edit, :update, :destroy]
 
   def index
-    @posts = comfy_paginate(@blog.posts.order(:published_at))
+    @posts = comfy_paginate(@blog.posts.includes(:categories).for_category(params[:category]).order(:published_at))
   end
 
   def new

--- a/app/controllers/comfy/blog/posts_controller.rb
+++ b/app/controllers/comfy/blog/posts_controller.rb
@@ -48,6 +48,7 @@ class Comfy::Blog::PostsController < Comfy::Blog::BaseController
 
   rescue ActiveRecord::RecordNotFound
     render :cms_page => '/404', :status => 404
+    return
   end
 
 end

--- a/app/controllers/comfy/blog/posts_controller.rb
+++ b/app/controllers/comfy/blog/posts_controller.rb
@@ -20,12 +20,14 @@ class Comfy::Blog::PostsController < Comfy::Blog::BaseController
   end
 
   def index
-    scope = if params[:year]
-      scope = @blog.posts.published.for_year(params[:year])
-      params[:month] ? scope.for_month(params[:month]) : scope
-    else
-      @blog.posts.published
+    scope = @blog.posts.published
+
+    if params[:year]
+      scope = scope.for_year(params[:year])
+      scope = scope.for_month(params[:month]) if params[:month]
     end
+
+    scope = scope.for_category(params[:category]) if params[:category]
 
     limit = ComfyBlog.config.posts_per_page
     respond_to do |format|

--- a/app/models/comfy/blog/post.rb
+++ b/app/models/comfy/blog/post.rb
@@ -1,20 +1,22 @@
 class Comfy::Blog::Post < ActiveRecord::Base
-  
+
   self.table_name = 'comfy_blog_posts'
-  
+
+  cms_is_categorized
+
   # -- Relationships --------------------------------------------------------
   belongs_to :blog
-  
+
   has_many :comments,
     :dependent => :destroy
-  
+
   # -- Validations ----------------------------------------------------------
   validates :blog_id, :title, :slug, :year, :month, :content,
     :presence   => true
   validates :slug,
     :uniqueness => { :scope => [:blog_id, :year, :month] },
     :format => { :with => /\A%*\w[a-z0-9_\-\%]*\z/i }
-  
+
   # -- Scopes ---------------------------------------------------------------
   default_scope -> {
     order('published_at DESC')
@@ -28,25 +30,25 @@ class Comfy::Blog::Post < ActiveRecord::Base
   scope :for_month, -> month {
     where(:month => month)
   }
-  
+
   # -- Callbacks ------------------------------------------------------------
   before_validation :set_slug,
                     :set_published_at,
                     :set_date
-  
+
 protected
-  
+
   def set_slug
     self.slug ||= self.title.to_s.downcase.slugify
   end
-  
+
   def set_date
     self.year   = self.published_at.year
     self.month  = self.published_at.month
   end
-  
+
   def set_published_at
     self.published_at ||= Time.zone.now
   end
-  
+
 end

--- a/app/views/comfy/admin/blog/posts/_form.html.haml
+++ b/app/views/comfy/admin/blog/posts/_form.html.haml
@@ -3,6 +3,9 @@
 = form.text_field :author
 = form.text_area :content, :data => {'cms-rich-text' => true}
 = form.text_area :excerpt, :class => 'short'
+
+= render :partial => 'comfy/admin/cms/categories/form', :object => form
+
 = form.text_field :published_at, :value => @post.published_at.try(:to_s, :db), :data => {'cms-datetime' => true}
 = form.form_group :is_published do
   = form.check_box :is_published

--- a/app/views/comfy/admin/blog/posts/index.html.haml
+++ b/app/views/comfy/admin/blog/posts/index.html.haml
@@ -4,11 +4,14 @@
 
 = comfy_paginate @posts
 
+= render :partial => 'comfy/admin/cms/categories/index', :object => 'Comfy::Blog::Post'
+
 %table.table.table-hover
   %tr
     %th.main= t('.title')
     %th= t('.author')
     %th= t('.published')
+    %th= t('.categories')
     %th= t('.comments')
     %th
 
@@ -22,6 +25,8 @@
         = post.author
       %td
         = post.published_at.try(:to_s, :db)
+      %td
+        = render :partial => 'comfy/admin/cms/categories/categories', :object => post
       %td
         = link_to t('.comment_count', :count => post.comments.count), comfy_admin_blog_comments_path(@site, @blog, :post_id => post.id), :class => 'btn btn-sm btn-info'
       %td

--- a/app/views/comfy/blog/posts/_categories.html.haml
+++ b/app/views/comfy/blog/posts/_categories.html.haml
@@ -1,0 +1,4 @@
+- if post.categories.present?
+  %ul
+    - post.categories.each do |category|
+      %li= link_to category.label, comfy_blog_posts_path(@cms_site.path, @blog.path, :category => category.label)

--- a/app/views/comfy/blog/posts/index.html.haml
+++ b/app/views/comfy/blog/posts/index.html.haml
@@ -7,6 +7,9 @@
     = post.author
   .date
     = post.published_at.to_s(:db)
+  .categories
+    = render 'categories', :post => post
+
   .content
     = post.content.html_safe
 

--- a/app/views/comfy/blog/posts/show.html.haml
+++ b/app/views/comfy/blog/posts/show.html.haml
@@ -6,6 +6,8 @@
   = @post.author
 .date
   = @post.published_at.to_s(:db)
+.categories
+  = render 'comfy/blog/posts/categories', :post => @post
 .content
   = @post.content.html_safe
 

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -83,6 +83,7 @@ cs:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -83,6 +83,7 @@ da:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -83,6 +83,7 @@ de:
             edit: Ändern
             delete: Löschen
             confirm_message: Sind Sie sicher?
+            categories: Kategorien
           new:
             page_title: Neuer Blogbeitrag
           edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -83,6 +83,7 @@ es:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -83,6 +83,7 @@ fr:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -83,6 +83,7 @@ it:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -83,6 +83,7 @@ ja:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -83,6 +83,7 @@ nb:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -83,6 +83,7 @@ nl:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -83,6 +83,7 @@ pl:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -83,6 +83,7 @@ pt-BR:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -83,6 +83,7 @@ ru:
             edit: Редактировать
             delete: Удалить
             confirm_message: Вы уверены?
+            categories: категории
           new:
             page_title: Новая запись блога
           edit:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -83,6 +83,7 @@ sv:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -83,6 +83,7 @@ uk:
             edit: Редактировать
             delete: Удалить
             confirm_message: Вы уверены?
+            categories: категорії
           new:
             page_title: Новая запись блога
           edit:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -83,6 +83,7 @@ zh-CN:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -83,6 +83,7 @@ zh-TW:
             edit: Edit
             delete: Delete
             confirm_message: Are you sure?
+            categories: Categories
           new:
             page_title: New blog post
           edit:

--- a/test/controllers/comfy/admin/blog/posts_controller_test.rb
+++ b/test/controllers/comfy/admin/blog/posts_controller_test.rb
@@ -1,20 +1,38 @@
 require_relative '../../../../test_helper'
 
 class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
-  
+
   def setup
     @site = comfy_cms_sites(:default)
     @blog = comfy_blog_blogs(:default)
     @post = comfy_blog_posts(:default)
   end
-  
+
   def test_get_index
     get :index, :site_id => @site, :blog_id => @blog
     assert_response :success
     assert assigns(:posts)
     assert_template :index
   end
-  
+
+  def test_get_index_with_category
+    category = @site.categories.create!(:label => 'Test Category', :categorized_type => 'Comfy::Blog::Post')
+    category.categorizations.create!(:categorized => @post)
+
+    get :index, :site_id => @site, :blog_id => @blog, :category => category.label
+    assert_response :success
+    assert assigns(:posts)
+    assert_equal 1, assigns(:posts).count
+    assert assigns(:posts).first.categories.member? category
+  end
+
+  def test_get_index_with_category_invalid
+    get :index, :site_id => @site, :blog_id => @blog, :category => 'invalid'
+    assert_response :success
+    assert assigns(:posts)
+    assert_equal 0, assigns(:posts).count
+  end
+
   def test_get_new
     get :new, :site_id => @site, :blog_id => @blog
     assert_response :success
@@ -22,7 +40,7 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
     assert_template :new
     assert_select "form[action='/admin/sites/#{@site.id}/blogs/#{@blog.id}/posts']"
   end
-  
+
   def test_get_new_with_default_author
     ComfyBlog.config.default_author = 'Default Author'
     get :new, :site_id => @site, :blog_id => @blog
@@ -30,7 +48,7 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:post)
     assert_equal 'Default Author', assigns(:post).author
   end
-  
+
   def test_creation
     assert_difference 'Comfy::Blog::Post.count' do
       post :create, :site_id => @site, :blog_id => @blog, :post => {
@@ -46,7 +64,7 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
       assert_equal 'Blog Post created', flash[:success]
     end
   end
-  
+
   def test_creation_failure
     assert_no_difference 'Comfy::Blog::Post.count' do
       post :create, :site_id => @site, :blog_id => @blog, :post => { }
@@ -56,7 +74,7 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
       assert_equal 'Failed to create Blog Post', flash[:error]
     end
   end
-  
+
   def test_get_edit
     get :edit, :site_id => @site, :blog_id => @blog, :id => @post
     assert_response :success
@@ -64,14 +82,14 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:post)
     assert_select "form[action='/admin/sites/#{@site.id}/blogs/#{@blog.id}/posts/#{@post.id}']"
   end
-  
+
   def test_get_edit_failure
     get :edit, :site_id => @site, :blog_id => @blog, :id => 'invalid'
     assert_response :redirect
     assert_redirected_to :action => :index
     assert_equal 'Blog Post not found', flash[:error]
   end
-  
+
   def test_update
     put :update, :site_id => @site, :blog_id => @blog, :id => @post, :post => {
       :title => 'Updated Post'
@@ -79,11 +97,11 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_redirected_to :action => :edit, :id => assigns(:post)
     assert_equal 'Blog Post updated', flash[:success]
-    
+
     @post.reload
     assert_equal 'Updated Post', @post.title
   end
-  
+
   def test_update_failure
     put :update, :site_id => @site, :blog_id => @blog, :id => @post, :post => {
       :title => ''
@@ -91,11 +109,11 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template :edit
     assert_equal 'Failed to update Blog Post', flash[:error]
-    
+
     @post.reload
     assert_not_equal '', @post.title
   end
-  
+
   def test_destroy
     assert_difference 'Comfy::Blog::Post.count', -1 do
       delete :destroy, :site_id => @site, :blog_id => @blog, :id => @post
@@ -104,5 +122,5 @@ class Comfy::Admin::Blog::PostsControllerTest < ActionController::TestCase
       assert_equal 'Blog Post removed', flash[:success]
     end
   end
-  
+
 end

--- a/test/controllers/comfy/blog/posts_controller_test.rb
+++ b/test/controllers/comfy/blog/posts_controller_test.rb
@@ -1,12 +1,12 @@
 require_relative '../../../test_helper'
 
 class Comfy::Blog::PostsControllerTest < ActionController::TestCase
-  
+
   def setup
     @blog = comfy_blog_blogs(:default)
     @post = comfy_blog_posts(:default)
   end
-  
+
   def test_get_index
     get :serve
     assert_response :success
@@ -14,7 +14,7 @@ class Comfy::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:posts)
     assert_equal 1, assigns(:posts).size
   end
-  
+
   def test_get_index_as_rss
     get :serve, :format => :rss
     assert_response :success
@@ -22,59 +22,74 @@ class Comfy::Blog::PostsControllerTest < ActionController::TestCase
     assert assigns(:posts)
     assert_equal 1, assigns(:posts).size
   end
-  
+
   def test_get_index_with_unpublished
     comfy_blog_posts(:default).update_column(:is_published, false)
     get :serve
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_index_for_year_archive
     get :index, :year => 2012
     assert_response :success
     assert_equal 1, assigns(:posts).size
-    
+
     get :index, :year => 1999
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
   def test_get_index_for_month_archive
     get :index, :year => 2012, :month => 1
     assert_response :success
     assert_equal 1, assigns(:posts).size
-    
+
     get :index, :year => 2012, :month => 12
     assert_response :success
     assert_equal 0, assigns(:posts).size
   end
-  
+
+  def test_get_index_for_category
+    category = comfy_cms_sites(:default).categories.create!(:label => 'Test Category', :categorized_type => 'Comfy::Blog::Post')
+    category.categorizations.create!(:categorized => @post)
+
+    get :serve, :category => 'Test Category'
+    assert_response :success
+    assert_template :index
+    assert_equal 1, assigns(:posts).size
+
+    get :serve, :category => 'invalid'
+    assert_response :success
+    assert_template :index
+    assert_equal 0, assigns(:posts).size
+  end
+
   def test_get_show
     get :serve, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_unpublished
     @post.update_attribute(:is_published, false)
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :serve, :slug => @post.slug
     end
   end
-  
+
   def test_get_show_with_date
     get :show, :year => @post.year, :month => @post.month, :slug => @post.slug
     assert_response :success
     assert_template :show
     assert assigns(:post)
   end
-  
+
   def test_get_show_with_date_invalid
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get :show, :year => '1999', :month => '99', :slug => 'invalid'
     end
   end
-  
+
 end


### PR DESCRIPTION
- List categories on Posts#index and Posts#show
- Filter Posts#index by clicking categories in list
- Add categories toolbar to blog post admin
- List categories in blog post index table rows
- Provide checkboxes for categories in admin post form
- Fix double render error on blog 404
