### PR TITLE
Respect Blog.path even when only 1 blog

### DIFF
--- a/app/controllers/comfy/blog/posts_controller.rb
+++ b/app/controllers/comfy/blog/posts_controller.rb
@@ -6,7 +6,7 @@ class Comfy::Blog::PostsController < Comfy::Blog::BaseController
   # action. let's figure it out here.
   def serve
     # if there are more than one blog, blog_path is expected
-    if @cms_site.blogs.count >= 2
+    if @cms_site.blogs.count >= 2 || @cms_site.blogs.first.path.present?
       params[:blog_path] = params.delete(:slug) if params[:blog_path].blank?
     end
 


### PR DESCRIPTION
Scenario:
comfy_route :blog, path: 'blogs'
Single blog with path='news'

Old behaviour:
Visiting /blogs/news yields 404 (!)
Visiting /blogs renders the news index
Posts exist at /blogs/news/my-post

New behaviour:
Visiting /blogs/news renders the news index
Visiting /blogs renders the news index
Posts exist at /blogs/news/my-post

I think it's better to respect the blog path if it is set, especially because posts exist at a URL including the path. This fix does that while maintaining the current behaviour of indexing the posts at the route when there is only one blog.
